### PR TITLE
feat!: run launch.py under layerdivider anytime

### DIFF
--- a/run_gui.ps1
+++ b/run_gui.ps1
@@ -1,2 +1,3 @@
+Set-Location $PSScriptRoot
 .\venv\Scripts\activate
 python.exe launch.py $args


### PR DESCRIPTION
いつでも layerdivider ディレクトリ直下の
venv\Script\activate
launch.py
を実行するように run_gui.ps1 ファイルの先頭に
Set-Location $PSScriptRoot
を付け加えました。

close #20 